### PR TITLE
[9.0][FIX]web_advanced_search_x2x:check logical operator before adding element to the domain

### DIFF
--- a/web_advanced_search_x2x/static/src/js/web_advanced_search_x2x.js
+++ b/web_advanced_search_x2x/static/src/js/web_advanced_search_x2x.js
@@ -123,18 +123,33 @@ odoo.define('web_advanced_search_x2x.search_filters', function (require) {
                 event.stopPropagation();
             });
         },
+        is_logical_operator: function(element){
+            // test whether a element is a logical operator ('|' or '&', '!')
+            if (element === '|' || element === '&' || element === '!') {
+                return true;
+            }
+            else{
+                return false;
+            }
+        },
         get_domain: function () {
             // Special way to get domain if user chose "domain" filter
+            var self = this;
             if (this.get_operator() == "domain") {
                 var value = this._x2x_field.get_value();
                 var domain = new data.CompoundDomain(),
                     name = this.field.name;
                 $.map(value, function (el) {
-                    domain.add([[
-                        _.str.sprintf("%s.%s", name, el[0]),
-                        el[1],
-                        el[2],
-                    ]]);
+                    if (self.is_logical_operator(el)){
+                        domain.add([el]);
+                    }
+                    else {
+                        domain.add([[
+                            _.str.sprintf("%s.%s", name, el[0]),
+                            el[1],
+                            el[2],
+                        ]]);
+                    }
                 });
                 return domain;
             } else {


### PR DESCRIPTION
**Actual Behavior:** the `get_domain` method updates the domain returned by the search on the field, by _blindly_ prefixing each first element of a tuple with the field name. In another word if we have a domain a `product_id` field such `[('name', 'ilike', 'something'), ('default_code', 'ilike', 'something')]` the `get_domain` will return `[('product.name', 'ilike', 'something'), ('default.default_code', 'ilike', 'something')]`.
**The issue:** Sometimes the domain doesn't just contain tuples but it may contain logical operators such `|, &, !` ( exemple: `['|', ('product.name', 'ilike', 'something'), ('default.default_code', 'ilike', 'something')]`).
**The solution:** I've added a utilty method `is_logical_operator` to check wether a domain element is a logical operator or not. if the element is a logical operator add it as it is. Else prefix the first element of a tuple with the field name.